### PR TITLE
Minor build fixes.

### DIFF
--- a/go/huffman/huffman_test.go
+++ b/go/huffman/huffman_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/blanu/Dust/go/DustModel/huffman"
+	"github.com/blanu/Dust/go/huffman"
 )
 
 var _ = huffman.NewCoding

--- a/go/prim1/asym_dh.go
+++ b/go/prim1/asym_dh.go
@@ -6,7 +6,7 @@ package prim
 import (
 	"errors"
 
-	"code.google.com/p/go.crypto/curve25519"
+	"golang.org/x/crypto/curve25519"
 	"github.com/agl/ed25519/extra25519"
 )
 


### PR DESCRIPTION
 * Unbreak the huffman test due to incorrect import path.
 * Use golang.org instead of code.google.com for Go's crypto package.